### PR TITLE
Feature/multi mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Binaries and executables
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Log files
+*.log
+
+# Go workspace file
+go.work
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Environment variables
+.env
+
+# Build directory
+bin/
+dist/
+
+# Test coverage
+coverage.txt
+coverage.html
+
+# Debug files
+debug
+
+# Dependency directories (remove if you're committing vendor/)
+vendor/ 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,145 @@
-# MQTT_LoadTest
-Load Testing tool for MQTT
+# MQTT Load Testing Tool
+
+A high-performance load testing tool for MQTT brokers, supporting various testing patterns and configurations.
+
+## Features
+- Multiple testing modes (pairwise, N-to-1, 1-to-N, many-to-many)
+- Configurable QoS levels and message retention
+- Detailed performance metrics and statistics
+- TLS/SSL support
+- Automatic reconnection handling
+- Customizable client behaviors
 
 ## Prerequisites
-- Go 1.21
-- Docker
+- Go 1.21 or higher
+- Docker (optional, for local broker testing)
 
-## Build
+## Installation
 ```bash
-go build -o mqtt-load-tester main.go
+git clone https://github.com/yourusername/mqtt-load-tester
+cd mqtt-load-tester
+go build
 ```
 
 ## Usage
+
+### Basic Command
 ```bash
-./mqtt-load-tester --clients 100 --rate 1000 --duration 60 --topic-prefix loadtest/ --username auth --password auth --qos 0 --prefix loadtest-client- --sub-clients 50 --retain
-
-Usage of ./mqtt-load-tester:
-      --broker string         MQTT broker URL (default "tcp://localhost:1883")
-      --clients int           Number of concurrent clients (default 100)
-      --duration int          Test duration in seconds (default 60)
-      --password string       MQTT password (default "auth")
-      --prefix string         Client ID prefix (default "loadtest-client-")
-      --qos int               MQTT QoS level (0, 1, or 2)
-      --rate int              Messages per second per client (default 1000)
-      --retain                Retain published messages
-      --size int              Size of each message in bytes (default 100)
-      --sub-clients int       Number of subscribing clients (default 50)
-      --topic-prefix string   Prefix for MQTT topics (default "loadtest/")
-      --username string       MQTT username (default "auth")
-
-# Pairwise mode (default) - each publisher paired with one subscriber
-go run . --mode pairwise --clients 10 
-# will be ignored --sub-clients 10
-
-# N-to-1 mode - multiple publishers to one subscriber
-go run . --mode ntone --clients 500 --sub-clients 100
-
-# 1-to-N mode - one publisher to multiple subscribers
-go run . --mode oton --clients 1 --sub-clients 100
-
-# Many-to-many mode - all subscribers receive messages from all publishers
-go run . --mode mtom --clients 10 --sub-clients 5
+./mqtt-load-tester [options]
 ```
 
-## Docker
-```bash
-docker run -d --name mosquitto -p 1883:1883 -p 9001:9001 eclipse-mosquitto
+### Test Modes
+
+1. **Pairwise Mode** (Default)
+   - Each publisher paired with one subscriber to a dedicated topic (will be ignored --sub-clients)
+   ```bash
+   ./mqtt-load-tester --mode pairwise --clients 10
+   ```
+
+2. **N-to-1 Mode**
+   - Multiple publishers to one subscriber
+   ```bash
+   ./mqtt-load-tester --mode ntone --clients 5 --sub-clients 1
+   ```
+
+3. **1-to-N Mode**
+   - One publisher to multiple subscribers
+   ```bash
+   ./mqtt-load-tester --mode oton --clients 1 --sub-clients 5
+   ```
+
+4. **Many-to-Many Mode**
+   - All subscribers receive messages from all publishers
+   ```bash
+   ./mqtt-load-tester --mode mtom --clients 10 --sub-clients 5
+   ```
+
+### Configuration Options
 ```
+--broker string            MQTT broker URL (default "tcp://localhost:1883")
+--clients int             Number of publishers (default 1)
+--sub-clients int         Number of subscribers (default 1)
+--rate int               Messages per second per publisher (default 10)
+--size int               Message size in bytes (default 100)
+--duration int           Test duration in seconds (default 30)
+--qos int                MQTT QoS level (0, 1, or 2)
+--retain                 Retain messages (default false)
+--topic string           Topic prefix (default "loadtest/")
+--username string        MQTT username
+--password string        MQTT password
+```
+
+### Advanced Options
+```
+--clean-session bool      Clean session on connect (default true)
+--auto-reconnect bool     Auto reconnect on connection loss (default true)
+--resume-subs bool        Resume subscriptions after reconnect (default true)
+--order-matters bool      Maintain message order (default false)
+--msg-channel-depth uint  Message channel buffer size (default 1000)
+--insecure-skip-verify   Skip TLS certificate verification (default true)
+```
+
+## Example Basic Test
+```bash
+
+./mqtt-load-tester --broker tcp://localhost:1883 --mode pairwise --clients 5 --duration 60
+./mqtt-load-tester --broker ssl://localhost:1883 --mode ntone --clients 5 --sub-clients 1 --duration 60
+./mqtt-load-tester --broker tcp://localhost:1883 --mode oton --clients 1 --sub-clients 5 --duration 60
+./mqtt-load-tester --broker ssl://localhost:1883 --mode mtom --clients 10 --sub-clients 5 --duration 60
+```
+
+## Example of Result
+```bash
+=== Final Test Results ===
+Total Publishers: 2000
+Total Subscribers: 2000
+Message Rate Per Client: 10
+Testing Mode: pairwise
+Test Duration: 600.87 seconds
+
+=== Message Statistics ===
+Total Messages Published: 11875842
+Total Messages Received: 11857338
+Messages Lost: 18504 (0.16%)
+Dropped Messages: 17645
+Duplicate Messages: 18504
+Out of Order Messages: 17611
+Processing Errors: 0
+
+=== Performance Metrics ===
+Average Publishing Rate: 19764.27 msg/sec
+Average Receiving Rate: 19733.48 msg/sec
+Average Publishing Rate Per Channel: 9.88 msg/sec
+Average Receiving Rate Per Channel: 9.87 msg/sec
+
+=== Error Statistics ===
+Total Errors: 0
+Retry Attempts: 0
+Successful Retries: 0
+Timeout Errors: 0
+Connection Errors: 0
+```
+
+## License
+
+MIT License
+
+Copyright (c) 2024 [LiamChan]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # MQTT_LoadTest
 Load Testing tool for MQTT
 
+## Prerequisites
+- Go 1.21
+- Docker
 
+## Build
 ```bash
-go run main.go --clients 100 --rate 1000 --duration 60 --topic-prefix loadtest/ --username auth --password auth --qos 0 --prefix loadtest-client- --sub-clients 50 --retain
+go build -o mqtt-load-tester main.go
+```
+
+## Usage
+```bash
+./mqtt-load-tester --clients 100 --rate 1000 --duration 60 --topic-prefix loadtest/ --username auth --password auth --qos 0 --prefix loadtest-client- --sub-clients 50 --retain
 
 Usage of ./mqtt-load-tester:
       --broker string         MQTT broker URL (default "tcp://localhost:1883")
@@ -18,4 +27,22 @@ Usage of ./mqtt-load-tester:
       --sub-clients int       Number of subscribing clients (default 50)
       --topic-prefix string   Prefix for MQTT topics (default "loadtest/")
       --username string       MQTT username (default "auth")
+
+# Pairwise mode (default) - each publisher paired with one subscriber
+go run . --mode pairwise --clients 10 
+# will be ignored --sub-clients 10
+
+# N-to-1 mode - multiple publishers to one subscriber
+go run . --mode ntone --clients 500 --sub-clients 100
+
+# 1-to-N mode - one publisher to multiple subscribers
+go run . --mode oton --clients 1 --sub-clients 100
+
+# Many-to-many mode - all subscribers receive messages from all publishers
+go run . --mode mtom --clients 10 --sub-clients 5
+```
+
+## Docker
+```bash
+docker run -d --name mosquitto -p 1883:1883 -p 9001:9001 eclipse-mosquitto
 ```

--- a/client.go
+++ b/client.go
@@ -116,17 +116,17 @@ func NewClient(id int, config *Config, stats *Stats, isSubscriber bool) (*Client
 		SetClientID(clientID).
 		SetUsername(config.Username).
 		SetPassword(config.Password).
-		SetCleanSession(false).
-		SetAutoReconnect(true).
-		SetKeepAlive(60 * time.Second).
-		SetPingTimeout(20 * time.Second).
-		SetConnectTimeout(30 * time.Second).
-		SetWriteTimeout(10 * time.Second).
-		SetMaxReconnectInterval(5 * time.Second).
-		SetConnectRetryInterval(2 * time.Second).
-		SetResumeSubs(true).
-		SetOrderMatters(false).
-		SetMessageChannelDepth(1000).
+		SetCleanSession(config.CleanSession).
+		SetAutoReconnect(config.AutoReconnect).
+		SetKeepAlive(30 * time.Second).
+		SetPingTimeout(10 * time.Second).
+		SetConnectTimeout(10 * time.Second).
+		SetWriteTimeout(5 * time.Second).
+		SetMaxReconnectInterval(time.Second).
+		SetConnectRetryInterval(time.Second).
+		SetResumeSubs(config.ResumeSubs).
+		SetOrderMatters(config.OrderMatters).
+		SetMessageChannelDepth(config.MessageChannelDepth).
 		SetStore(mqtt.NewMemoryStore()).
 		SetOnConnectHandler(func(client mqtt.Client) {
 			fmt.Printf("Client %s connected successfully at %v\n", 
@@ -145,7 +145,7 @@ func NewClient(id int, config *Config, stats *Stats, isSubscriber bool) (*Client
 	// Configure TLS if using SSL
 	if strings.HasPrefix(config.BrokerURL, "ssl://") {
 		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: config.InsecureSkipVerify,
 			MinVersion:       tls.VersionTLS12,
 			MaxVersion:       tls.VersionTLS13,
 			Renegotiation:    tls.RenegotiateNever,

--- a/config.go
+++ b/config.go
@@ -26,6 +26,14 @@ type Config struct {
 	QoS           int
 	RetainMessage bool
 	TestMode      TestMode
+	
+	// MQTT Client Options
+	CleanSession        bool
+	AutoReconnect       bool
+	ResumeSubs         bool
+	OrderMatters       bool
+	MessageChannelDepth uint
+	InsecureSkipVerify bool
 }
 
 func LoadConfig() *Config {
@@ -35,12 +43,20 @@ func LoadConfig() *Config {
 	topicPrefix := pflag.String("topic", "loadtest/", "Topic prefix")
 	numClients := pflag.Int("clients", 1, "Number of publisher clients")
 	subClients := pflag.Int("sub-clients", 1, "Number of subscriber clients")
-	publishRate := pflag.Int("rate", 1, "Messages per second per publisher")
+	publishRate := pflag.Int("rate", 10, "Messages per second per publisher")
 	messageSize := pflag.Int("size", 100, "Message size in bytes")
 	testDuration := pflag.Int("duration", 30, "Test duration in seconds")
 	qos := pflag.Int("qos", 0, "MQTT QoS level (0, 1, or 2)")
 	retain := pflag.Bool("retain", false, "Retain messages")
 	mode := pflag.String("mode", "pairwise", "Test mode (pairwise, ntone, oton, mtom)")
+
+	// MQTT Client Options
+	cleanSession := pflag.Bool("clean-session", false, "Clean session on connect")
+	autoReconnect := pflag.Bool("auto-reconnect", true, "Auto reconnect on connection loss")
+	resumeSubs := pflag.Bool("resume-subs", true, "Resume subscriptions after reconnect")
+	orderMatters := pflag.Bool("order-matters", false, "Maintain message order")
+	msgChannelDepth := pflag.Uint("msg-channel-depth", 1000, "Message channel buffer size")
+	insecureSkipVerify := pflag.Bool("insecure-skip-verify", true, "Skip TLS certificate verification")
 
 	pflag.Parse()
 
@@ -57,5 +73,13 @@ func LoadConfig() *Config {
 		QoS:           *qos,
 		RetainMessage: *retain,
 		TestMode:      TestMode(*mode),
+		
+		// MQTT Client Options
+		CleanSession:        *cleanSession,
+		AutoReconnect:       *autoReconnect,
+		ResumeSubs:         *resumeSubs,
+		OrderMatters:       *orderMatters,
+		MessageChannelDepth: *msgChannelDepth,
+		InsecureSkipVerify: *insecureSkipVerify,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -51,7 +51,7 @@ func LoadConfig() *Config {
 	mode := pflag.String("mode", "pairwise", "Test mode (pairwise, ntone, oton, mtom)")
 
 	// MQTT Client Options
-	cleanSession := pflag.Bool("clean-session", false, "Clean session on connect")
+	cleanSession := pflag.Bool("clean-session", true, "Clean session on connect")
 	autoReconnect := pflag.Bool("auto-reconnect", true, "Auto reconnect on connection loss")
 	resumeSubs := pflag.Bool("resume-subs", true, "Resume subscriptions after reconnect")
 	orderMatters := pflag.Bool("order-matters", false, "Maintain message order")

--- a/config.go
+++ b/config.go
@@ -4,38 +4,58 @@ import (
 	"github.com/spf13/pflag"
 )
 
+type TestMode string
+
+const (
+	ModePairwise  TestMode = "pairwise"  // 1:1 pub/sub pairs (default)
+	ModeNToOne    TestMode = "ntone"     // N publishers to 1 subscriber
+	ModeOneToN    TestMode = "oton"      // 1 publisher to N subscribers
+	ModeManyToMany TestMode = "mtom"     // M publishers to N subscribers
+)
+
 type Config struct {
 	BrokerURL     string
-	NumClients    int
-	MessageSize   int
-	PublishRate   int
-	TestDuration  int
-	TopicPrefix   string
 	Username      string
 	Password      string
-	QoS           int
-	ClientPrefix  string
+	TopicPrefix   string
+	NumClients    int
 	SubClients    int
+	PublishRate   int
+	MessageSize   int
+	TestDuration  int
+	QoS           int
 	RetainMessage bool
+	TestMode      TestMode
 }
 
 func LoadConfig() *Config {
-	cfg := &Config{}
-
-	pflag.StringVar(&cfg.BrokerURL, "broker", "tcp://localhost:1883", "MQTT broker URL")
-	pflag.IntVar(&cfg.NumClients, "clients", 100, "Number of concurrent clients")
-	pflag.IntVar(&cfg.MessageSize, "size", 100, "Size of each message in bytes")
-	pflag.IntVar(&cfg.PublishRate, "rate", 1000, "Messages per second per client")
-	pflag.IntVar(&cfg.TestDuration, "duration", 60, "Test duration in seconds")
-	pflag.StringVar(&cfg.TopicPrefix, "topic-prefix", "loadtest/", "Prefix for MQTT topics")
-	pflag.StringVar(&cfg.Username, "username", "auth", "MQTT username")
-	pflag.StringVar(&cfg.Password, "password", "auth", "MQTT password")
-	pflag.IntVar(&cfg.QoS, "qos", 0, "MQTT QoS level (0, 1, or 2)")
-	pflag.StringVar(&cfg.ClientPrefix, "prefix", "loadtest-client-", "Client ID prefix")
-	pflag.IntVar(&cfg.SubClients, "sub-clients", 50, "Number of subscribing clients")
-	pflag.BoolVar(&cfg.RetainMessage, "retain", false, "Retain published messages")
+	brokerURL := pflag.String("broker", "tcp://localhost:1883", "MQTT broker URL")
+	username := pflag.String("username", "", "MQTT username")
+	password := pflag.String("password", "", "MQTT password")
+	topicPrefix := pflag.String("topic", "loadtest/", "Topic prefix")
+	numClients := pflag.Int("clients", 1, "Number of publisher clients")
+	subClients := pflag.Int("sub-clients", 1, "Number of subscriber clients")
+	publishRate := pflag.Int("rate", 1, "Messages per second per publisher")
+	messageSize := pflag.Int("size", 100, "Message size in bytes")
+	testDuration := pflag.Int("duration", 30, "Test duration in seconds")
+	qos := pflag.Int("qos", 0, "MQTT QoS level (0, 1, or 2)")
+	retain := pflag.Bool("retain", false, "Retain messages")
+	mode := pflag.String("mode", "pairwise", "Test mode (pairwise, ntone, oton, mtom)")
 
 	pflag.Parse()
 
-	return cfg
+	return &Config{
+		BrokerURL:     *brokerURL,
+		Username:      *username,
+		Password:      *password,
+		TopicPrefix:   *topicPrefix,
+		NumClients:    *numClients,
+		SubClients:    *subClients,
+		PublishRate:   *publishRate,
+		MessageSize:   *messageSize,
+		TestDuration:  *testDuration,
+		QoS:           *qos,
+		RetainMessage: *retain,
+		TestMode:      TestMode(*mode),
+	}
 }

--- a/main.go
+++ b/main.go
@@ -232,6 +232,7 @@ func printFinalStats(stats *Stats, config *Config, elapsed float64) {
     fmt.Printf("Total Publishers: %d\n", config.NumClients)
     fmt.Printf("Total Subscribers: %d\n", config.SubClients)
 	fmt.Printf("Message Rate Per Client: %d\n", config.PublishRate)
+	fmt.Printf("Testing Mode: %s\n", config.TestMode)
     fmt.Printf("Test Duration: %.2f seconds\n", elapsed)
     
     fmt.Printf("\n=== Message Statistics ===\n")


### PR DESCRIPTION
1. **Pairwise Mode** (Default)
   - Each publisher paired with one subscriber to a dedicated topic (will be ignored --sub-clients)
   ```bash
   ./mqtt-load-tester --mode pairwise --clients 10
   ```

2. **N-to-1 Mode**
   - Multiple publishers to one subscriber
   ```bash
   ./mqtt-load-tester --mode ntone --clients 5 --sub-clients 1
   ```

3. **1-to-N Mode**
   - One publisher to multiple subscribers
   ```bash
   ./mqtt-load-tester --mode oton --clients 1 --sub-clients 5
   ```

4. **Many-to-Many Mode**
   - All subscribers receive messages from all publishers
   ```bash
   ./mqtt-load-tester --mode mtom --clients 10 --sub-clients 5
   ```